### PR TITLE
Changed layout and bindings

### DIFF
--- a/modules/homeManager/compositors/hyprland.nix
+++ b/modules/homeManager/compositors/hyprland.nix
@@ -15,14 +15,13 @@
       general =
       {
         hover_icon_on_border = false;
-        layout = "master";
+        layout = "dwindle";
         resize_on_border = false;
       };
-      master =
+      dwindle =
       {
-        mfact = 0.5;
-        new_status = "slave";
-        orientation = "center";
+        pseudotile = true;
+        force_split = 2;
       };
       input =
       {

--- a/modules/homeManager/compositors/hyprland/hyprlandBindings.nix
+++ b/modules/homeManager/compositors/hyprland/hyprlandBindings.nix
@@ -35,34 +35,33 @@ in
     in
     [
       # Execute default programs and actions
-      "${mainMod}, Return, exec, ${lib.getExe pkgs.kitty}"
+      "${mainMod}, RETURN, exec, ${lib.getExe pkgs.kitty}"
       "${mainMod}, E, exec, ${lib.getExe' pkgs.nemo-with-extensions "nemo"}"
       "${mainMod}, B, exec, zen"
       "${mainMod}, R, exec, ${menu}"
-      "${mainMod}, O, exec, ${lib.getExe pkgs.obs-studio}"
       "${mainMod}, L, exec, ${powerMenu}"
-      "${mainMod}, K, killactive,"
-      "${mainMod}, F, fullscreen,"
-      "${mainModShift}, L, exit,"
-      "${mainModShift}, V, togglefloating,"
       # OBS shortcuts
       "${mainMod}, F1, pass, ^(com\.obsproject\.Studio)$"
       "${mainMod}, F2, pass, ^(com\.obsproject\.Studio)$"
       # Change focused window
-      "${mainMod}, left, movefocus, l"
-      "${mainMod}, right, movefocus, r"
-      "${mainMod}, up, movefocus, u"
-      "${mainMod}, down, movefocus, d"
+      "${mainMod}, LEFT, movefocus, l"
+      "${mainMod}, RIGHT, movefocus, r"
+      "${mainMod}, UP, movefocus, u"
+      "${mainMod}, DOWN, movefocus, d"
       # Move focused window within workspace
-      "${mainModShift}, left, movewindow, l"
-      "${mainModShift}, right, movewindow, r"
-      "${mainModShift}, up, movewindow, u"
-      "${mainModShift}, down, movewindow, d"
-      # Cycle master window within workspace
-      "${mainModControl}, left, layoutmsg, rollnext"
-      "${mainModControl}, right, layoutmsg, rollprev"
-      # Make focused window Master
-      "${mainMod}, home, layoutmsg, swapwithmaster"
+      "${mainModShift}, LEFT, movewindow, l"
+      "${mainModShift}, RIGHT, movewindow, r"
+      "${mainModShift}, UP, movewindow, u"
+      "${mainModShift}, DOWN, movewindow, d"
+      # Layout shortcut
+      "${mainMod}, TAB, layoutmsg, swapsplit"
+      "${mainMod}, HOME, layoutmsg, movetoroot active unstable"
+      "${mainMod}, P, pseudo,"
+      # System
+      "${mainMod}, END, killactive,"
+      "${mainMod}, F, fullscreen,"
+      "${mainModShift}, L, exit,"
+      "${mainModShift}, V, togglefloating,"
       # Navigate between workspaces on the same monitor
       "${mainMod}, PAGE_DOWN, exec, hyprnome -k -c"
       "${mainMod}, PAGE_UP, exec, hyprnome -p -k -c"
@@ -80,9 +79,9 @@ in
       "${mainModAlt}, PAGE_UP, workspace, e+1"
       "${mainModAlt}, PAGE_DOWN, workspace, e-1"
       # Screenshot
-      "${mainMod}, F9, exec, hyprshot -m region --freeze"
-      "${mainMod}, F10, exec, hyprshot -m window -m active --freeze"
-      "${mainMod}, F11, exec, hyprshot -m output -m active --freeze"
+      ", PRINT, exec, hyprshot -m window -m active --freeze"
+      "${mainModShift}, PRINT, exec, hyprshot -m output -m active --freeze"
+      "${mainModControl}, PRINT, exec, hyprshot -m region --freeze"
     ];
   };
 }


### PR DESCRIPTION
This PR focuses on changing the layout used in hyprland from master to dwindle. 

Master layout lacks the ability to split slave windows horizontally, when masters position is left or right, only doing so when master is centered, which isnt very ergonomic when running a 32:9 monitor.

while Dwindle might not have a static window split config, something similar can be achieved by setting splitting direction and using the dispatcher "movetoroot unstable", which in terms of functionality, is essentially the same as master layout. One major advantage with dwindle is that since the split happens based on which axis is bigger, vertical monitor splits vertically, while ultra wide splits horizontally.

This change now allows for a something similar to master window one the left or right, with slaves splitting horizontally on the main monitor.