### PR TITLE
Feature/hypr tweaks add screen power cycle

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742213273,
-        "narHash": "sha256-0l0vDb4anfsBu1rOs94bC73Hub+xEivgBAo6QXl2MmU=",
+        "lastModified": 1743265529,
+        "narHash": "sha256-QbjP15/2N+VJl0b5jxrrTc+VOt39aU4XrDvtP0Lz5ik=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "484b732195cc53f4536ce4bd59a5c6402b1e7ccf",
+        "rev": "1d2dbd72c2bbaceab031c592d4810f744741d203",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742921081,
-        "narHash": "sha256-c1mq2EwulIoLng2oww3IozEGTarxuCBRJ5w5KIS0Mf4=",
+        "lastModified": 1743703189,
+        "narHash": "sha256-5s1zBM+pmpxvHInRbVScsueETRxVAi4EvDl4V3FzKjI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "ef953b78549dc877d958d002a8661cbb65e87a1f",
+        "rev": "d3d2a0d76c2d85a49f30cb50956b0e8d93ee6ec6",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742871411,
-        "narHash": "sha256-F3xBdOs5m0SE6Gq3jz+JxDOPvsLs22vbGfD05uF6xEc=",
+        "lastModified": 1743648554,
+        "narHash": "sha256-23JFd+zd2GamTTdnGuFVeIg8x8C3hLpQJRh/PGTORzo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
+        "rev": "107352dde4ff3c01cb5a0b3fe17f5beef37215bc",
         "type": "github"
       },
       "original": {
@@ -158,11 +158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742937932,
-        "narHash": "sha256-OrLDssbhEZvbHMljgT2mFNWacghm2HJBDTWlqTJNhO8=",
+        "lastModified": 1743869639,
+        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f565da89e759ebf57b236510aa955b8a2d41c779",
+        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742860753,
-        "narHash": "sha256-ItOsU1v6CZNe6spfKtJ+cpVr0S87jq69PYe3lpOLzjI=",
+        "lastModified": 1743895813,
+        "narHash": "sha256-Bj0DslgOrAxs16wSfVvkO8z6o+GF5VLSBn79I7pUZNQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "f7ba86d1f335112ae0d13548947ddbd76b1477b6",
+        "rev": "e96b8ce4cc5e5856b6da653f1d92af856b5e72c9",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738422629,
-        "narHash": "sha256-5v+bv75wJWvahyM2xcMTSNNxmV8a7hb01Eey5zYnBJw=",
+        "lastModified": 1743549251,
+        "narHash": "sha256-yf+AXt0RkAkCyF6iSnJt6EJAnNG/l6qv70CVzhRP6Bg=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "755aef8dab49d0fc4663c715fa4ad221b2aedaed",
+        "rev": "4ab17ccac08456cb5e00e8bd323de2efd30612be",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741534688,
-        "narHash": "sha256-EV3945SnjOCuRVbGRghsWx/9D89FyshnSO1Q6/TuQ14=",
+        "lastModified": 1742984269,
+        "narHash": "sha256-uz9FaCIbga/gQ5ZG1Hb4HVVjTWT1qjjCAFlCXiaefxg=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "dd1f720cbc2dbb3c71167c9598045dd3261d27b3",
+        "rev": "7248194a2ce0106ae647b70d0526a96dc9d6ad60",
         "type": "github"
       },
       "original": {
@@ -439,11 +439,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742465245,
-        "narHash": "sha256-gpjtkoeq5Ye9J8GoR+rWg3NL4bbEtcLvvF4nN6MtxdU=",
+        "lastModified": 1743660830,
+        "narHash": "sha256-ezJqPIuB25iMJeugwHKWnB1DjMvrdpkrPxE3TCULjGk=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "a95606cae5c9e1f5b84debe7865ef171d4deb287",
+        "rev": "c7ade1c8fe2bdb70d38b3b9a97b874dcaf33b755",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -493,11 +493,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -509,11 +509,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741934125,
-        "narHash": "sha256-qwI47l3aKXRpDvmCKDbLV70iVfAqhpuKqT7qYHA4KJk=",
+        "lastModified": 1742213273,
+        "narHash": "sha256-0l0vDb4anfsBu1rOs94bC73Hub+xEivgBAo6QXl2MmU=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "bea48d0bbe15fb3d758a8b6be865836c97056575",
+        "rev": "484b732195cc53f4536ce4bd59a5c6402b1e7ccf",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738664950,
-        "narHash": "sha256-xIeGNM+iivwVHkv9tHwOqoUP5dDrtees34bbFKKMZYs=",
+        "lastModified": 1742215578,
+        "narHash": "sha256-zfs71PXVVPEe56WEyNi2TJQPs0wabU4WAlq0XV7GcdE=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "7c6d165e1eb9045a996551eb9f121b6d1b30adc3",
+        "rev": "2fd36421c21aa87e2fe3bee11067540ae612f719",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742142447,
-        "narHash": "sha256-NiYQDTdLxWFtUh9Sl9cz7idk3IT59v7pORJF896RT3I=",
+        "lastModified": 1742468927,
+        "narHash": "sha256-3CBAs8OF0etCIaa4p+VyuXfLrL1cvD5E3Dmigqg2YOo=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d7382aa8a1a4785d2abf5bdd08055f0803a8f184",
+        "rev": "7ea4fbf0ba034d947339b3a94a10da022eca1988",
         "type": "github"
       },
       "original": {
@@ -493,11 +493,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "type": "github"
       },
       "original": {
@@ -533,11 +533,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741379162,
-        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
+        "lastModified": 1742058297,
+        "narHash": "sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
+        "rev": "59f17850021620cd348ad2e9c0c64f4e6325ce2a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742850686,
-        "narHash": "sha256-V8H6aMBvlbe0V/mUqcUEcjJWvUTros2z10fDmmxezM4=",
+        "lastModified": 1742921081,
+        "narHash": "sha256-c1mq2EwulIoLng2oww3IozEGTarxuCBRJ5w5KIS0Mf4=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "d1f17b8a063de7bd96c7119a68a380ffedffbdad",
+        "rev": "ef953b78549dc877d958d002a8661cbb65e87a1f",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742701794,
-        "narHash": "sha256-bJIFFa6/4vBGoNmCwjO5TCIbiveV2BRxVLqHcxk5jXw=",
+        "lastModified": 1742871411,
+        "narHash": "sha256-F3xBdOs5m0SE6Gq3jz+JxDOPvsLs22vbGfD05uF6xEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9172a6f956f7e0f7810861b9b1146f1c43d9abcb",
+        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
         "type": "github"
       },
       "original": {
@@ -158,11 +158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742851132,
-        "narHash": "sha256-8vEcDefstheV1whup+5fSpZu4g9Jr7WpYzOBKAMSHn4=",
+        "lastModified": 1742937932,
+        "narHash": "sha256-OrLDssbhEZvbHMljgT2mFNWacghm2HJBDTWlqTJNhO8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c4d5d72805d14ea43c140eeb70401bf84c0f11b4",
+        "rev": "f565da89e759ebf57b236510aa955b8a2d41c779",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1741998159,
-        "narHash": "sha256-mf3SzoEPxphBb5Ed5TS34BBbBKEZmQPFkrlZ8Bu4+dc=",
+        "lastModified": 1742142447,
+        "narHash": "sha256-NiYQDTdLxWFtUh9Sl9cz7idk3IT59v7pORJF896RT3I=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "e59680481d74fdfcc432bb9640ba2c979022c4c2",
+        "rev": "d7382aa8a1a4785d2abf5bdd08055f0803a8f184",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1741962175,
-        "narHash": "sha256-ZydxDII0DOv1Ut/QXFL9WtKLs9D+rS/khV8Nu0X+D3I=",
+        "lastModified": 1742850686,
+        "narHash": "sha256-V8H6aMBvlbe0V/mUqcUEcjJWvUTros2z10fDmmxezM4=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "30d7b193ce1e6d39390d7f6ffb700d33aedeffe6",
+        "rev": "d1f17b8a063de7bd96c7119a68a380ffedffbdad",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1741847799,
-        "narHash": "sha256-muvsng8/+e9AC+xg5HuHgHwuQ/etKlTevNgr8fw5r9s=",
+        "lastModified": 1742452566,
+        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "05f331e61277f70f55769060f783457fdacf8da1",
+        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741879521,
-        "narHash": "sha256-GylyCwdUe2Kd69bC8txEX+A3H/DXBZl2a+GcmTcJw/g=",
+        "lastModified": 1742701794,
+        "narHash": "sha256-bJIFFa6/4vBGoNmCwjO5TCIbiveV2BRxVLqHcxk5jXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b0efe3d335f452595512c7b275e5dddfbfb28a5",
+        "rev": "9172a6f956f7e0f7810861b9b1146f1c43d9abcb",
         "type": "github"
       },
       "original": {
@@ -158,11 +158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741955947,
-        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
+        "lastModified": 1742851132,
+        "narHash": "sha256-8vEcDefstheV1whup+5fSpZu4g9Jr7WpYzOBKAMSHn4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
+        "rev": "c4d5d72805d14ea43c140eeb70401bf84c0f11b4",
         "type": "github"
       },
       "original": {
@@ -439,11 +439,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741874414,
-        "narHash": "sha256-gtIrDkG/iap32MYyaSAlWaixshiqMyFB9eKyhcF66eM=",
+        "lastModified": 1742465245,
+        "narHash": "sha256-gpjtkoeq5Ye9J8GoR+rWg3NL4bbEtcLvvF4nN6MtxdU=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "662d117ac0ffc81f3e91b5f0fb800c3effd904a1",
+        "rev": "a95606cae5c9e1f5b84debe7865ef171d4deb287",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -509,11 +509,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1741807049,
-        "narHash": "sha256-/tH4gSW/0ePa2+0DAzk5xuHAa5qeaB4T8RnmiG3Ex4w=",
+        "lastModified": 1742296961,
+        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3fc655b239058deb93f503f9d25cc69a32ca7675",
+        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1742468927,
-        "narHash": "sha256-3CBAs8OF0etCIaa4p+VyuXfLrL1cvD5E3Dmigqg2YOo=",
+        "lastModified": 1742860753,
+        "narHash": "sha256-ItOsU1v6CZNe6spfKtJ+cpVr0S87jq69PYe3lpOLzjI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "7ea4fbf0ba034d947339b3a94a10da022eca1988",
+        "rev": "f7ba86d1f335112ae0d13548947ddbd76b1477b6",
         "type": "github"
       },
       "original": {
@@ -493,11 +493,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -533,11 +533,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742058297,
-        "narHash": "sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "59f17850021620cd348ad2e9c0c64f4e6325ce2a",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {

--- a/hosts/SmelterDeamon/hostSpecific/homeManager/monitorConfig.nix
+++ b/hosts/SmelterDeamon/hostSpecific/homeManager/monitorConfig.nix
@@ -2,6 +2,7 @@
 let
   mainMonitorRes = "5120x1440";
   mainMonitorPos = "0x640";
+  defaultRefreshRate = "120.00";
   mainMonitor = "desc:Samsung Electric Company Odyssey G95SC H1AK500000";
   bottomMonitor = "desc:Invalid Vendor Codename - RTK Verbatim MT14 demoset-1";
   sideMonitor = "desc:Acer Technologies ED323QUR";
@@ -15,12 +16,14 @@ in
   {
     name = "DP-1";
     res = mainMonitorRes;
-    oc = "240.00";
     pos = mainMonitorPos;
+    maxHz = "240.00";
+    midHz = defaultRefreshRate;
+    lowHz = "60.00";
   };
   wayland.windowManager.hyprland.settings.monitor =
   [
-    "${mainMonitor}, ${mainMonitorRes}@120.00, ${mainMonitorPos}, 1"
+    "${mainMonitor}, ${mainMonitorRes}@${defaultRefreshRate}, ${mainMonitorPos}, 1"
     "${bottomMonitor}, preferred, 1600x2080, 1"
     "${sideMonitor}, preferred, 5120x0, 1, transform, 1"
     ", preferred, auto, 1"

--- a/modules/homeManager/compositorTools/hyprTweaks.nix
+++ b/modules/homeManager/compositorTools/hyprTweaks.nix
@@ -5,7 +5,9 @@ let
   xrandr = lib.getExe pkgs.xorg.xrandr;
   mainMonName = config.desktop.system.mainMon.name;
   mainMonRes = config.desktop.system.mainMon.res;
-  mainMonOc = config.desktop.system.mainMon.oc;
+  maxHz = config.desktop.system.mainMon.maxHz;
+  midHz = config.desktop.system.mainMon.midHz;
+  lowHz = config.desktop.system.mainMon.lowHz;
   mainMonPos = config.desktop.system.mainMon.pos;
 in
 {
@@ -13,52 +15,73 @@ in
   [(
     writeShellScriptBin "hyprTweaks"
     ''
+      function set_config()
+      {
+        hyprCommand=$1
+        notifyGroup=$2
+        notifyMessage=$3
+        
+        ${hyprctl} keyword "monitor ${mainMonName}, disable"
+        
+        sleep 5s
+        
+        ${hyprctl} --batch $hyprCommand
+        
+        sleep 5s
+        
+        ${hyprctl} dispatch focusmonitor ${mainMonName}
+        
+        ${xrandr} --output ${mainMonName} --primary
+        
+        ${dunstify} -u normal "$notifyGroup" "$notifyMessage"
+      }
+      
       adaptiveSync=false
       fullColorRange=false
+      reload=false
+      preferredHz=""
       
       hyprCommand="keyword animations:enabled false;"
       hyprCommand+=" keyword decoration:blur:enabled false;"
       hyprCommand+=" keyword general:allow_tearing true;"
       
-      notifyGroup="Hyprland Tweaks"
-      notifyMessage="Tweaks on:"
+      notifyGroup="Hyprtweaks"
+      notifyMessage="Tweaks on"
       
-      if [[ "${mainMonName}" == "" || "${mainMonRes}" == "" || "${mainMonOc}" == "" || "${mainMonPos}" == "" ]]; then
+      if [[ "${mainMonName}" == "" || "${mainMonRes}" == "" || "${maxHz}" == "" || "${midHz}" == "" || "${lowHz}" == "" || "${mainMonPos}" == "" ]]; then
         ${dunstify} -u critical "$notifyGroup" "Missing main monitor config!"
         exit 1
       fi
       
-      monitorConfig="monitor ${mainMonName}, ${mainMonRes}@${mainMonOc}, ${mainMonPos}, 1"
-      
-      while getopts ":acdhpr" opt; do
+      while getopts "p:acdhr" opt; do
         case $opt in
           a)
             adaptiveSync=true
-            notifyMessage+=" VRR"
+            notifyMessage+=", VRR"
             ;;
           c)
             hyprCommand+=" keyword cursor:min_refresh_rate 0;"
             hyprCommand+=" keyword cursor:no_break_fs_vrr 2;"
             hyprCommand+=" keyword cursor:no_hardware_cursors true;"
-            notifyMessage+=" SC"
+            notifyMessage+=", SC"
             ;;
           d)
             hyprCommand+=" keyword render:direct_scanout 2;"
-            notifyMessage+=" DS"
+            notifyMessage+=", DS"
             ;;
           h)
             fullColorRange=true
             hyprCommand+=" keyword experimental:xx_color_management_v4 true;"
-            notifyMessage+=" HDR"
+            notifyMessage+=", HDR"
             ;;
           p)
-            monitorConfig="monitor ${mainMonName}, preferred, ${mainMonPos}, 1"
-            notifyMessage+=" preferred"
+            preferredHz=$OPTARG
+            notifyMessage+=", Hz"
             ;;
           r)
-            ${hyprctl} reload
-            ${dunstify} -u normal "$notifyGroup" "Reloaded Hyprland."
-            exit 0
+            reload=true
+            preferredHz="mid"
+            notifyMessage="Reloaded Hyprland"
             ;;
           ?)
             ${dunstify} -u critical "$notifyGroup" "Unknown parameters!"
@@ -67,31 +90,19 @@ in
         esac
       done
       
-      if $adaptiveSync; then
-        monitorConfig+=", vrr, 2"
-      fi
+      refreshRate="${maxHz}"
+      refreshRate=$([[ $preferredHz == "mid" ]] && echo "${midHz}" || echo $refreshRate)
+      refreshRate=$([[ $preferredHz == "low" ]] && echo "${lowHz}" || echo $refreshRate)
       
-      if $fullColorRange; then
-        monitorConfig+=", bitdepth, 10"
-      fi
+      monitorConfig="monitor ${mainMonName}, ${mainMonRes}@$refreshRate, ${mainMonPos}, 1"
       
-      if $maxRefreshRate || $adaptiveSync || $bitdepth; then
-        hyprCommand+=" keyword $monitorConfig;"
-      fi
+      $reload && ${hyprctl} reload && set_config "keyword $monitorConfig;" "$notifyGroup" "reloaded hyprland" && exit 0
       
-      ${hyprctl} keyword "monitor ${mainMonName}, disable"
+      monitorConfig+=$($adaptiveSync && echo ", vrr, 2" || echo "")
+      monitorConfig+=$($fullColorRange && echo ", bitdepth, 10" || echo "")
+      hyprCommand+=$($adaptiveSync || $bitdepth && echo " keyword $monitorConfig;" || echo "")
       
-      sleep 5s
-      
-      ${hyprctl} --batch $hyprCommand
-      
-      sleep 15s
-      
-      ${hyprctl} dispatch focusmonitor ${mainMonName}
-      
-      ${xrandr} --output ${mainMonName} --primary
-      
-      ${dunstify} -u normal "$notifyGroup" "$notifyMessage"
+      set_config "$hyprCommand" "$notifyGroup" "$notifyMessage"
     ''
   )];
 }

--- a/modules/homeManager/customOptions/desktopSystemOptions.nix
+++ b/modules/homeManager/customOptions/desktopSystemOptions.nix
@@ -32,12 +32,22 @@
         type = lib.types.str;
         default = "";
       };
-      oc = lib.mkOption
+      pos = lib.mkOption
       {
         type = lib.types.str;
         default = "";
       };
-      pos = lib.mkOption
+      maxHz = lib.mkOption
+      {
+        type = lib.types.str;
+        default = "";
+      };
+      midHz = lib.mkOption
+      {
+        type = lib.types.str;
+        default = "";
+      };
+      lowHz = lib.mkOption
       {
         type = lib.types.str;
         default = "";

--- a/modules/nixos/software/gaming.nix
+++ b/modules/nixos/software/gaming.nix
@@ -2,19 +2,15 @@
 {
   environment.systemPackages = with pkgs;
   [
-    gpu-screen-recorder-gtk
     heroic
     jstest-gtk
     libstrangle
     mangohud
     mangojuice
     protonplus
-    protonup-qt
     ryujinx
     scanmem
-    vesktop
     vkbasalt
-    vkbasalt-cli
   ];
   programs =
   {
@@ -26,19 +22,6 @@
     {
       enable = true;
       enableRenice = true;
-    };
-    gpu-screen-recorder =
-    {
-      enable = true;
-    };
-    obs-studio =
-    {
-      enable = true;
-      enableVirtualCamera = true;
-      plugins = with pkgs.obs-studio-plugins;
-      [
-        obs-vkcapture
-      ];
     };
     steam =
     {

--- a/modules/nixos/software/generalSoftware.nix
+++ b/modules/nixos/software/generalSoftware.nix
@@ -3,20 +3,41 @@
   environment.systemPackages = with pkgs;
   [
     bottles
-    celluloid
-    davinci-resolve
-    ffmpeg-full
-    gapless
-    handbrake
-    krita
-    lollypop
-    moonlight-qt
-    onlyoffice-desktopeditors
     python3Full
     resources
-    teams-for-linux
+  ] ++ [
+    gpu-screen-recorder-gtk
+    moonlight-qt
+  ] ++ [
+    handbrake
+    drawing
+    pitivi
+  ] ++ [
+    celluloid
+    gapless
+    image-roll
+  ] ++ [
     thunderbird
-    vipsdisp
+    onlyoffice-desktopeditors
     xfce.mousepad
+  ] ++ [
+    teams-for-linux
+    vesktop
   ];
+  programs =
+  {
+    gpu-screen-recorder =
+    {
+      enable = true;
+    };
+    obs-studio =
+    {
+      enable = true;
+      enableVirtualCamera = true;
+      plugins = with pkgs.obs-studio-plugins;
+      [
+        obs-vkcapture
+      ];
+    };
+  };
 }

--- a/modules/nixos/software/generalSoftware.nix
+++ b/modules/nixos/software/generalSoftware.nix
@@ -21,6 +21,7 @@
   ] ++ [
     thunderbird
     onlyoffice-desktopeditors
+    libreoffice
     xfce.mousepad
   ] ++ [
     teams-for-linux

--- a/modules/nixos/software/generalSoftware.nix
+++ b/modules/nixos/software/generalSoftware.nix
@@ -10,7 +10,9 @@
     moonlight-qt
   ] ++ [
     handbrake
-    drawing
+    davinci-resolve
+    gimp
+    pinta
     pitivi
   ] ++ [
     celluloid

--- a/modules/nixos/software/generalSoftware.nix
+++ b/modules/nixos/software/generalSoftware.nix
@@ -20,7 +20,6 @@
     image-roll
   ] ++ [
     thunderbird
-    onlyoffice-desktopeditors
     libreoffice
     xfce.mousepad
   ] ++ [

--- a/modules/nixos/software/terminal.nix
+++ b/modules/nixos/software/terminal.nix
@@ -11,6 +11,7 @@
     unzip
     usbutils
     tmux
+    wf-recorder
   ];
   programs.fish =
   {


### PR DESCRIPTION
This PR focuses on enhancing the hyprTweak script, allowing for the selection of refresh rates and adds the ability to boot cycle the screens connection when reloading hyprland. Parts of the scripts have also been refactored.

Additionally, this pr removes Qt apps which have GTK alternative, for a more unified experience, while updating all flakes their latest commits.

Finally, specific modules have been refactored for better separation between responsibilities.