### PR TITLE
Feature/add winboat to system

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765606130,
-        "narHash": "sha256-KOP4QnkiRwiD5KEOr6ceF67rfTP1OqPmCCft6xDC3k4=",
+        "lastModified": 1765860045,
+        "narHash": "sha256-7Lxp/PfOy4h3QIDtmWG/EgycaswqRSkDX4DGtet14NE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d787ec69c3216ea33be1c0424fe65cb23aa8fb31",
+        "rev": "09de9577d47d8bffb11c449b6a3d24e32ac16c99",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
+        "lastModified": 1765779637,
+        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
+        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -139,6 +139,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1765762245,
+        "narHash": "sha256-3iXM/zTqEskWtmZs3gqNiVtRTsEjYAedIaLL0mSBsrk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c8cfcd6ccd422e41cc631a0b73ed4d5a925c393d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1765472234,
@@ -159,7 +175,8 @@
       "inputs": {
         "chaotic": "chaotic",
         "home-manager": "home-manager_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,15 +7,18 @@
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
   };
   
-  outputs = inputs@{self, chaotic, nixpkgs, home-manager, ...}:
+  outputs = inputs@{self, chaotic, nixpkgs, nixpkgs-stable, home-manager, ...}:
   let
+    arch = "x86_64-linux";
     desktops =
     [
       { name = "SmelterDeamon"; user = "ashen_one"; }
       { name = "Susanoo"; user = "order_shadow"; }
     ];
+    pkgs-stable = nixpkgs-stable.legacyPackages.${arch};
   in
   {
     nixosConfigurations = nixpkgs.lib.listToAttrs (map (host: 
@@ -23,12 +26,12 @@
       name = host.name;
       value = nixpkgs.lib.nixosSystem
       {
-        system = "x86_64-linux";
+        system = arch;
         specialArgs =
         {
           host = host.name;
           user = host.user;
-          inherit inputs;
+          inherit pkgs-stable;
         };
         modules =
         [
@@ -50,7 +53,6 @@
               {
                 host = host.name;
                 user = host.user;
-                inherit inputs;
               };
             };
           }

--- a/hosts/SmelterDeamon/hostSpecific/nixos/storageConfig.nix
+++ b/hosts/SmelterDeamon/hostSpecific/nixos/storageConfig.nix
@@ -19,14 +19,4 @@
       "x-gvfs-show"
     ];
   };
-  fileSystems."/mnt/SATASSD1" =
-  {
-    device = "/dev/disk/by-label/SATASSD1";
-    fsType = "ext4";
-    options = 
-    [
-      "nofail"
-      "x-gvfs-show"
-    ];
-  };
 }

--- a/hosts/SmelterDeamon/hostSpecific/nixos/userConfig.nix
+++ b/hosts/SmelterDeamon/hostSpecific/nixos/userConfig.nix
@@ -12,6 +12,7 @@
       "kvm" 
       "libvirtd"
       "gamemode"
+      "docker"
     ];
   };
 }

--- a/modules/homeManager/compositors/niri/niriBindings.nix
+++ b/modules/homeManager/compositors/niri/niriBindings.nix
@@ -65,15 +65,15 @@ in
     '';
     monitorBinds =
     ''
-      ${mainModAlt}+Right      { focus-monitor-right; }
-      ${mainModAlt}+Left       { focus-monitor-left; }
-      ${mainModAlt}+Up         { focus-monitor-up; }
-      ${mainModAlt}+Down       { focus-monitor-down; }
-      ${mainModShiftAlt}+Right { move-column-to-monitor-right; }
-      ${mainModShiftAlt}+Left  { move-column-to-monitor-left; }
-      ${mainModShiftAlt}+Up    { move-column-to-monitor-up; }
-      ${mainModShiftAlt}+Down  { move-column-to-monitor-down; }
-      ${mainModShiftAlt}+P     { power-off-monitors; }
+      ${mainModAlt}+Right       { focus-monitor-right; }
+      ${mainModAlt}+Left        { focus-monitor-left; }
+      ${mainModAlt}+Up          { focus-monitor-up; }
+      ${mainModAlt}+Down        { focus-monitor-down; }
+      ${mainModShiftAlt}+Right  { move-column-to-monitor-right; }
+      ${mainModShiftAlt}+Left   { move-column-to-monitor-left; }
+      ${mainModShiftAlt}+Up     { move-column-to-monitor-up; }
+      ${mainModShiftAlt}+Down   { move-column-to-monitor-down; }
+      ${mainModShiftAlt}+Delete { power-off-monitors; }
     '';
     workspaceBinds =
     ''
@@ -92,9 +92,9 @@ in
     '';
     screenshotBinds =
     ''
-      ${mainMod}+Print      { screenshot-screen; }
-      ${mainModShift}+Print { screenshot; }
-      ${mainModCtrl}+Print  { screenshot-window; }
+      ${mainMod}+P      { screenshot-screen; }
+      ${mainModShift}+P { screenshot; }
+      ${mainModCtrl}+P  { screenshot-window; }
     '';
     mediaBinds =
     ''

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -12,7 +12,6 @@
     ./hardware/kernel.nix
     ./hardware/printing.nix
     ./hardware/sound.nix
-    ./software/devApps.nix
     ./software/flatpak.nix
     ./software/gamingApps.nix
     ./software/systemApps.nix

--- a/modules/nixos/software/devApps.nix
+++ b/modules/nixos/software/devApps.nix
@@ -1,7 +1,0 @@
-{pkgs, ...}:
-{
-  environment.systemPackages = with pkgs;
-  [
-    python314
-  ];
-}

--- a/modules/nixos/software/systemApps.nix
+++ b/modules/nixos/software/systemApps.nix
@@ -23,6 +23,8 @@
     # Tools
     qbittorrent
     bottles
+    # SDKs
+    python314
   ];
   programs =
   {

--- a/modules/nixos/software/virtualisation.nix
+++ b/modules/nixos/software/virtualisation.nix
@@ -1,11 +1,11 @@
-{config, lib, pkgs, ...}:
+{config, lib, pkgs, pkgs-stable, ...}:
 {
   config = lib.mkIf (config.desktop.software.virtualization)
   {
-    environment.systemPackages = with pkgs;
+    environment.systemPackages =
     [
-      winboat
-      podman-compose
+      pkgs.winboat
+      pkgs-stable.docker-compose
     ];
     programs.virt-manager =
     {
@@ -13,7 +13,11 @@
     };
     virtualisation =
     {
-      podman.enable = true;
+      docker = 
+      {
+        enable = true;
+        package = pkgs-stable.docker;
+      };
       libvirtd.enable = true;
       spiceUSBRedirection.enable = true;
     };

--- a/modules/nixos/software/virtualisation.nix
+++ b/modules/nixos/software/virtualisation.nix
@@ -1,4 +1,4 @@
-{config, lib, ...}:
+{config, lib, pkgs, ...}:
 {
   config = lib.mkIf (config.desktop.software.virtualization)
   {

--- a/modules/nixos/software/virtualisation.nix
+++ b/modules/nixos/software/virtualisation.nix
@@ -2,12 +2,18 @@
 {
   config = lib.mkIf (config.desktop.software.virtualization)
   {
+    environment.systemPackages = with pkgs;
+    [
+      winboat
+      podman-compose
+    ];
     programs.virt-manager =
     {
       enable = true;
     };
     virtualisation =
     {
+      podman.enable = true;
       libvirtd.enable = true;
       spiceUSBRedirection.enable = true;
     };


### PR DESCRIPTION
This Pr focuses on getting winboat running as an alternative emulator, using docker as its back-end. Additionally it adds a new input, from which packages from stable channels can be pulled instead of unstable, this allows fro greater flexibility incase packages break in the future.